### PR TITLE
feat(sidemenu): overlay content

### DIFF
--- a/js/angular/directive/sideMenu.js
+++ b/js/angular/directive/sideMenu.js
@@ -13,7 +13,8 @@
  * <ion-side-menu
  *   side="left"
  *   width="myWidthValue + 20"
- *   is-enabled="shouldLeftSideMenuBeEnabled()">
+ *   is-enabled="shouldLeftSideMenuBeEnabled()"
+ *   display-type="push">
  * </ion-side-menu>
  * ```
  * For a complete side menu example, see the
@@ -22,6 +23,7 @@
  * @param {string} side Which side the side menu is currently on.  Allowed values: 'left' or 'right'.
  * @param {boolean=} is-enabled Whether this side menu is enabled.
  * @param {number=} width How many pixels wide the side menu should be.  Defaults to 275.
+ * @param {string} display-type Which type of display the menu should have.  Allowed values: 'push' or 'overlay'.  Defaults to 'push'.
  */
 IonicModule
 .directive('ionSideMenu', function() {
@@ -32,6 +34,7 @@ IonicModule
     compile: function(element, attr) {
       angular.isUndefined(attr.isEnabled) && attr.$set('isEnabled', 'true');
       angular.isUndefined(attr.width) && attr.$set('width', '275');
+      angular.isUndefined(attr.displayType) && attr.$set('displayType', 'push');
 
       element.addClass('menu menu-' + attr.side);
 
@@ -41,7 +44,8 @@ IonicModule
         var sideMenu = sideMenuCtrl[$scope.side] = new ionic.views.SideMenu({
           width: attr.width,
           el: $element[0],
-          isEnabled: true
+          isEnabled: true,
+          displayType: attr.displayType
         });
 
         $scope.$watch($attr.width, function(val) {
@@ -53,8 +57,12 @@ IonicModule
         $scope.$watch($attr.isEnabled, function(val) {
           sideMenu.setIsEnabled(!!val);
         });
+        $scope.$watch($attr.displayType, function(val) {
+          if (val == 'push' || val == 'overlay') {
+            sideMenu.setDisplayType(val);
+          }
+        });
       };
     }
   };
 });
-

--- a/js/angular/directive/sideMenu.js
+++ b/js/angular/directive/sideMenu.js
@@ -37,6 +37,11 @@ IonicModule
       angular.isUndefined(attr.displayType) && attr.$set('displayType', 'push');
 
       element.addClass('menu menu-' + attr.side);
+      if (attr.displayType == 'overlay') {
+        element.addClass('menu-animated');
+        element[0].style[attr.side] = '-' + attr.width + 'px';
+        element[0].style.zIndex = 2147483647; // top most, maximum zIndex value
+      }
 
       return function($scope, $element, $attr, sideMenuCtrl) {
         $scope.side = $attr.side || 'left';

--- a/js/views/sideMenuView.js
+++ b/js/views/sideMenuView.js
@@ -11,6 +11,7 @@
       this.el = opts.el;
       this.isEnabled = (typeof opts.isEnabled === 'undefined') ? true : opts.isEnabled;
       this.setWidth(opts.width);
+      this.displayType = (typeof opts.displayType === 'undefined') ? 'push' : opts.displayType;
     },
     getFullWidth: function() {
       return this.width;
@@ -31,6 +32,9 @@
       if(this.el.style.zIndex !== '-1') {
         this.el.style.zIndex = '-1';
       }
+    },
+    setDisplayType: function(displayType) {
+      this.displayType = displayType;
     }
   });
 

--- a/js/views/sideMenuView.js
+++ b/js/views/sideMenuView.js
@@ -35,7 +35,21 @@
     },
     setDisplayType: function(displayType) {
       this.displayType = displayType;
-    }
+    },
+    enableAnimation: function() {
+      this.animationEnabled = true;
+      this.el.classList.add('menu-animated');
+    },
+    disableAnimation: function() {
+      this.animationEnabled = false;
+      this.el.classList.remove('menu-animated');
+    },
+    getTranslateX: function() {
+      return parseFloat(this.el.style[ionic.CSS.TRANSFORM].replace('translate3d(', '').split(',')[0]);
+    },
+    setTranslateX: ionic.animationFrameThrottle(function(x) {
+      this.el.style[ionic.CSS.TRANSFORM] = 'translate3d(' + x + 'px, 0, 0)';
+    })
   });
 
   ionic.views.SideMenuContent = ionic.views.View.inherit({

--- a/test/unit/angular/controller/sideMenuController.unit.js
+++ b/test/unit/angular/controller/sideMenuController.unit.js
@@ -69,6 +69,18 @@ describe('$ionicSideMenus controller', function() {
     expect(ctrl.right.isEnabled).toEqual(true);
   });
 
+  // Menu displayType
+  it('should set displayType', function() {
+    ctrl.left.setDisplayType('overlay');
+    ctrl.right.setDisplayType('overlay');
+    expect(ctrl.left.displayType).toEqual('overlay');
+    expect(ctrl.right.displayType).toEqual('overlay');
+    ctrl.left.setDisplayType('push');
+    ctrl.right.setDisplayType('push');
+    expect(ctrl.left.displayType).toEqual('push');
+    expect(ctrl.right.displayType).toEqual('push');
+  });
+
   // Menu widths
   it('should init widths', function() {
     expect(ctrl.left.width).toEqual(270);

--- a/test/unit/views/sideMenu.unit.js
+++ b/test/unit/views/sideMenu.unit.js
@@ -12,5 +12,6 @@ describe('SideMenu', function() {
   it('Should init', function() {
     expect(menu.width).toEqual(270);
     expect(menu.isEnabled).toEqual(true);
+    expect(menu.displayType).toEqual('push');
   });
 });


### PR DESCRIPTION
#### Short description of what this resolves:

Resolves situations when you want to display menu as overlay of the content instead of pushing it to left/right

#### Changes proposed in this pull request:

- added property display-type to ion-side-menu directive

**Ionic Version**: 1.x