### PR TITLE
feat(sidemenu): leaving content active when menu is open

### DIFF
--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -164,18 +164,21 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
    */
   self.openPercentage = function(percentage) {
     var p = percentage / 100;
+    var leaveContentActive = false;
 
     if (self.left && percentage >= 0) {
       self.openAmount(self.left.width * p);
+      leaveContentActive = self.left.leaveContentActive;
     } else if (self.right && percentage < 0) {
       self.openAmount(self.right.width * p);
+      leaveContentActive = self.right.leaveContentActive;
     }
 
-    // add the CSS class "menu-open" if the percentage does not
-    // equal 0, otherwise remove the class from the body element
-    $ionicBody.enableClass((percentage !== 0), 'menu-open');
+    // add the CSS class "menu-open" if don't want to leave content active and the
+    // percentage does not equal 0, otherwise remove the class from the body element
+    $ionicBody.enableClass((!leaveContentActive && percentage !== 0), 'menu-open');
 
-    self.content.setCanScroll(percentage == 0);
+    self.content.setCanScroll(leaveContentActive || percentage == 0);
   };
 
   /*

--- a/js/angular/directive/sideMenu.js
+++ b/js/angular/directive/sideMenu.js
@@ -14,7 +14,8 @@
  *   side="left"
  *   width="myWidthValue + 20"
  *   is-enabled="shouldLeftSideMenuBeEnabled()"
- *   display-type="push">
+ *   display-type="push"
+ *   leave-content-active="shouldLeftSideMenuLeaveMainContentActive()">
  * </ion-side-menu>
  * ```
  * For a complete side menu example, see the
@@ -24,6 +25,7 @@
  * @param {boolean=} is-enabled Whether this side menu is enabled.
  * @param {number=} width How many pixels wide the side menu should be.  Defaults to 275.
  * @param {string} display-type Which type of display the menu should have.  Allowed values: 'push' or 'overlay'.  Defaults to 'push'.
+ * @param {boolean=} leave-content-active Whether this menu should leave main content active when menu is opened.  Defaults to false.
  */
 IonicModule
 .directive('ionSideMenu', function() {
@@ -35,6 +37,7 @@ IonicModule
       angular.isUndefined(attr.isEnabled) && attr.$set('isEnabled', 'true');
       angular.isUndefined(attr.width) && attr.$set('width', '275');
       angular.isUndefined(attr.displayType) && attr.$set('displayType', 'push');
+      angular.isUndefined(attr.leaveContentActive) && attr.$set('leaveContentActive', 'false');
 
       element.addClass('menu menu-' + attr.side);
       if (attr.displayType == 'overlay') {
@@ -50,7 +53,8 @@ IonicModule
           width: attr.width,
           el: $element[0],
           isEnabled: true,
-          displayType: attr.displayType
+          displayType: attr.displayType,
+          leaveContentActive: false
         });
 
         $scope.$watch($attr.width, function(val) {
@@ -66,6 +70,9 @@ IonicModule
           if (val == 'push' || val == 'overlay') {
             sideMenu.setDisplayType(val);
           }
+        });
+        $scope.$watch($attr.leaveContentActive, function(val) {
+          sideMenu.setLeaveContentActive(!!val);
         });
       };
     }

--- a/js/views/sideMenuView.js
+++ b/js/views/sideMenuView.js
@@ -12,6 +12,7 @@
       this.isEnabled = (typeof opts.isEnabled === 'undefined') ? true : opts.isEnabled;
       this.setWidth(opts.width);
       this.displayType = (typeof opts.displayType === 'undefined') ? 'push' : opts.displayType;
+      this.leaveContentActive = (typeof opts.leaveContentActive === 'undefined') ? false : opts.leaveContentActive;
     },
     getFullWidth: function() {
       return this.width;
@@ -49,7 +50,10 @@
     },
     setTranslateX: ionic.animationFrameThrottle(function(x) {
       this.el.style[ionic.CSS.TRANSFORM] = 'translate3d(' + x + 'px, 0, 0)';
-    })
+    }),
+    setLeaveContentActive: function(leaveContentActive) {
+      this.leaveContentActive = leaveContentActive;
+    }
   });
 
   ionic.views.SideMenuContent = ionic.views.View.inherit({

--- a/test/unit/angular/controller/sideMenuController.unit.js
+++ b/test/unit/angular/controller/sideMenuController.unit.js
@@ -81,6 +81,18 @@ describe('$ionicSideMenus controller', function() {
     expect(ctrl.right.displayType).toEqual('push');
   });
 
+  // Menu leaveContentActive
+  it('should set leaveContentActive', function() {
+    ctrl.left.setLeaveContentActive(true);
+    ctrl.right.setLeaveContentActive(true);
+    expect(ctrl.left.leaveContentActive).toEqual(true);
+    expect(ctrl.right.leaveContentActive).toEqual(true);
+    ctrl.left.setLeaveContentActive(false);
+    ctrl.right.setLeaveContentActive(false);
+    expect(ctrl.left.leaveContentActive).toEqual(false);
+    expect(ctrl.right.leaveContentActive).toEqual(false);
+  });
+
   // Menu widths
   it('should init widths', function() {
     expect(ctrl.left.width).toEqual(272);

--- a/test/unit/views/sideMenu.unit.js
+++ b/test/unit/views/sideMenu.unit.js
@@ -13,5 +13,6 @@ describe('SideMenu', function() {
     expect(menu.width).toEqual(270);
     expect(menu.isEnabled).toEqual(true);
     expect(menu.displayType).toEqual('push');
+    expect(menu.leaveContentActive).toEqual(false);
   });
 });


### PR DESCRIPTION
#### Short description of what this resolves:

This is useful when you want to open menu leaving main content active.

#### Changes proposed in this pull request:

- added attribute "leave-content-active" to "ion-side-menu" directive

**Ionic Version**: 1.x