### PR TITLE
fix: using uuid instead of deprecated node-uuid

### DIFF
--- a/config/gulp-tasks/test.js
+++ b/config/gulp-tasks/test.js
@@ -6,7 +6,7 @@ var gutil = require('gulp-util');
 var http = require('http');
 var karma = require('karma').server;
 var path = require('canonical-path');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var projectRoot = path.resolve(__dirname, '../..');
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "mkdirp": "^0.3.5",
     "node-libs-browser": "^0.5.2",
     "node-twitter-api": "^1.2.2",
-    "node-uuid": "^1.4.1",
     "phantomjs-prebuilt": "^2.1.7",
     "protractor": "^0.23.1",
     "q": "^1.0.1",
@@ -65,6 +64,7 @@
     "sauce-connect-launcher": "^0.2.2",
     "semver": "^2.2.1",
     "through": "^2.3.4",
+    "uuid": "^3.0.1",
     "winston": "^0.7.2"
   },
   "licenses": [


### PR DESCRIPTION
#### Short description of what this resolves:

fix: using uuid instead of deprecated node-uuid

**Ionic Version**: 1.x